### PR TITLE
icon color can be colored by default while creating new terminal

### DIFF
--- a/lib/platformio-ide-terminal.coffee
+++ b/lib/platformio-ide-terminal.coffee
@@ -226,6 +226,12 @@ module.exports =
       type: 'object'
       order: 5
       properties:
+        iconWithColor:
+          title: 'Icon Has Color By Default'
+          description: 'Icon has Color while creating terminal'
+          type: 'boolean'
+          default: false
+          order: 1
         red:
           title: 'Status Icon Red'
           description: 'Red color used for status icon.'

--- a/lib/status-bar.coffee
+++ b/lib/status-bar.coffee
@@ -175,9 +175,7 @@ class StatusBar extends View
     statusIcon = new StatusIcon()
     platformIOTerminalView = new PlatformIOTerminalView(id, pwd, statusIcon, this, shell, args, autoRun)
 
-    iconColors = ['red', 'orange', 'yellow'
-                  'green', 'blue', 'purple'
-                  'pink', 'cyan', 'magenta']
+    iconColors = (c for c in Object.keys atom.config.get 'platformio-ide-terminal.iconColors' when c isnt 'iconWithColor')
     statusIcon.initialize(platformIOTerminalView)
 
     if atom.config.get 'platformio-ide-terminal.iconColors.iconWithColor'

--- a/lib/status-bar.coffee
+++ b/lib/status-bar.coffee
@@ -174,7 +174,15 @@ class StatusBar extends View
 
     statusIcon = new StatusIcon()
     platformIOTerminalView = new PlatformIOTerminalView(id, pwd, statusIcon, this, shell, args, autoRun)
+
+    iconColors = ['red', 'orange', 'yellow'
+                  'green', 'blue', 'purple'
+                  'pink', 'cyan', 'magenta']
     statusIcon.initialize(platformIOTerminalView)
+
+    if atom.config.get 'platformio-ide-terminal.iconColors.iconWithColor'
+      iconColor = iconColors[@statusContainer.find('.pio-terminal-status-icon').length % iconColors.length]
+      statusIcon.setColor atom.config.get("platformio-ide-terminal.iconColors.#{iconColor}").toRGBAString()
 
     platformIOTerminalView.attach()
 

--- a/lib/status-icon.coffee
+++ b/lib/status-icon.coffee
@@ -97,4 +97,7 @@ class StatusIcon extends HTMLElement
       @name.innerHTML = name
       @terminalView.emit 'did-change-title'
 
+  setColor: (color) ->
+    @style.color = color if color
+
 module.exports = document.registerElement('pio-terminal-status-icon', prototype: StatusIcon.prototype, extends: 'li')


### PR DESCRIPTION
Currently, all icons are gray-colored while creating a new terminal.
I added an option to enable that icon can be colored automatically while creating a new terminal.
All colors are retrieved from config.iconColors. 
