### PR TITLE
Focus terminal before closing it

### DIFF
--- a/lib/view.coffee
+++ b/lib/view.coffee
@@ -253,7 +253,10 @@ class PlatformIOTerminalView extends View
     return if @animating
 
     if @panel.isVisible()
-      @hide()
+      if @terminal.cursorState
+        @hide()
+      else
+        @terminal.focus()
     else
       @open()
 


### PR DESCRIPTION
When using the toggle key it will check if the terminal is focused before closing it.
It is useful when you leave the terminal open and want to quickly go back to the terminal.

I actually check if the terminal is focused by looking at the cursor which is not the best way to check it, but I have not found another way to check if a terminal is focused