### PR TITLE
Fix deprecation warning in Atom 1.13

### DIFF
--- a/lib/status-bar.coffee
+++ b/lib/status-bar.coffee
@@ -60,6 +60,7 @@ class StatusBar extends View
       else if item.constructor.name is "TextEditor"
         mapping = atom.config.get('platformio-ide-terminal.core.mapTerminalsTo')
         return if mapping is 'None'
+        return unless item.getPath()
 
         switch mapping
           when 'File'
@@ -70,9 +71,8 @@ class StatusBar extends View
         prevTerminal = @getActiveTerminalView()
         if prevTerminal != nextTerminal
           if not nextTerminal?
-            if item.getTitle() isnt 'untitled'
-              if atom.config.get('platformio-ide-terminal.core.mapTerminalsToAutoOpen')
-                nextTerminal = @createTerminalView()
+            if atom.config.get('platformio-ide-terminal.core.mapTerminalsToAutoOpen')
+              nextTerminal = @createTerminalView()
           else
             @setActiveTerminalView(nextTerminal)
             nextTerminal.toggle() if prevTerminal?.panel.isVisible()


### PR DESCRIPTION
`item.getPath()` returns undefined, causing `path.dirname` to throw a warning.

This happens when you create a new file.  Since we know this is a new file (with no path, unsaved) we can also remove the `item.getTitle() isnt 'untitled'` check as we'll have exited above in the guard clause.