### PR TITLE
Feature: One-Dark Theme

### DIFF
--- a/lib/platformio-ide-terminal.coffee
+++ b/lib/platformio-ide-terminal.coffee
@@ -128,7 +128,8 @@ module.exports =
             'silver-aerogel',
             'solarized-dark',
             'solid-colors',
-            'dracula'
+            'dracula',
+            'one-dark'
           ]
     ansiColors:
       type: 'object'

--- a/styles/themes.less
+++ b/styles/themes.less
@@ -14,4 +14,5 @@
   @import 'themes/solarized-dark';
   @import 'themes/solid-colors';
   @import 'themes/dracula';
+  @import 'themes/one-dark';
 }

--- a/styles/themes/one-dark.less
+++ b/styles/themes/one-dark.less
@@ -1,0 +1,12 @@
+.one-dark {
+  background-color: #282C34;
+  color: white;
+
+  ::selection {
+    background-color: #44475a;
+  }
+
+  .terminal-cursor {
+    background-color: #99BBFF;
+  }
+}


### PR DESCRIPTION
Add pixel-perfect theme of the Atom default `One Dark` UI & Syntax.

### Screenshot
![screen shot 2016-12-30 at 2 21 17 pm](https://cloud.githubusercontent.com/assets/6811830/21573601/4c363c1c-ce9b-11e6-88c0-83dc32118659.png)