### PR TITLE
Clearer variable name in run provider

### DIFF
--- a/lib/platformio-ide-terminal.coffee
+++ b/lib/platformio-ide-terminal.coffee
@@ -8,8 +8,8 @@ module.exports =
     @statusBarTile = null
 
   provideRunInTerminal: ->
-    run: (command) =>
-      @statusBarTile.runCommandInNewTerminal command
+    run: (commands) =>
+      @statusBarTile.runCommandInNewTerminal commands
     getTerminalViews: () =>
       @statusBarTile.terminalViews
 


### PR DESCRIPTION
This just fixes a minor inconsistency since `commands` should be a list of strings.

I noticed this while working on https://github.com/lgeiger/hydrogen-launcher/pull/11