### PR TITLE
Feature select to copy

### DIFF
--- a/lib/platformio-ide-terminal.coffee
+++ b/lib/platformio-ide-terminal.coffee
@@ -36,6 +36,11 @@ module.exports =
           description: 'Run text inserted via `platformio-ide-terminal:insert-text` as a command? **This will append an end-of-line character to input.**'
           type: 'boolean'
           default: true
+        selectToCopy:
+          title: 'Select To Copy'
+          description: 'Copies text to clipboard when selection happens.'
+          type: 'boolean'
+          default: true
     core:
       type: 'object'
       order: 2

--- a/lib/view.coffee
+++ b/lib/view.coffee
@@ -71,6 +71,7 @@ class PlatformIOTerminalView extends View
     @xterm.on 'mouseup', (event) =>
       if event.which != 3
         text = window.getSelection().toString()
+        atom.clipboard.write(text) if atom.config.get('platformio-ide-terminal.toggles.selectToCopy') and text
         unless text
           @focus()
     @xterm.on 'dragenter', override


### PR DESCRIPTION
iTerm has a very nice feature that automatically copies selected text when selection happens, and a lot of people use that.

Also, there was someone who wanted this feature, so I've implemented it.
https://github.com/platformio/platformio-atom-ide-terminal/issues/123