### PR TITLE
Added terminal focus && keybinding.

### DIFF
--- a/keymaps/platformio-ide-terminal.cson
+++ b/keymaps/platformio-ide-terminal.cson
@@ -3,7 +3,7 @@
   'cmd-shift-j': 'platformio-ide-terminal:prev'
   'cmd-shift-k': 'platformio-ide-terminal:next'
   'cmd-shift-x': 'platformio-ide-terminal:close'
-  'cmd-alt-f': 'termination:focus'
+  'cmd-alt-f': 'platformio-ide-terminal:focus'
   'ctrl-enter': 'platformio-ide-terminal:insert-selected-text'
   'ctrl-`': 'platformio-ide-terminal:toggle'
 
@@ -14,7 +14,7 @@
   'alt-shift-x': 'platformio-ide-terminal:close'
   'ctrl-enter': 'platformio-ide-terminal:insert-selected-text'
   'ctrl-`': 'platformio-ide-terminal:toggle'
-  'ctrl-alt-f': 'termination:focus'
+  'ctrl-alt-f': 'platformio-ide-terminal:focus'
 
 '.platform-darwin .platformio-ide-terminal .terminal':
   'cmd-c': 'platformio-ide-terminal:copy'

--- a/keymaps/platformio-ide-terminal.cson
+++ b/keymaps/platformio-ide-terminal.cson
@@ -3,6 +3,7 @@
   'cmd-shift-j': 'platformio-ide-terminal:prev'
   'cmd-shift-k': 'platformio-ide-terminal:next'
   'cmd-shift-x': 'platformio-ide-terminal:close'
+  'cmd-alt-f': 'termination:focus'
   'ctrl-enter': 'platformio-ide-terminal:insert-selected-text'
   'ctrl-`': 'platformio-ide-terminal:toggle'
 
@@ -13,6 +14,7 @@
   'alt-shift-x': 'platformio-ide-terminal:close'
   'ctrl-enter': 'platformio-ide-terminal:insert-selected-text'
   'ctrl-`': 'platformio-ide-terminal:toggle'
+  'ctrl-alt-f': 'termination:focus'
 
 '.platform-darwin .platformio-ide-terminal .terminal':
   'cmd-c': 'platformio-ide-terminal:copy'

--- a/lib/status-bar.coffee
+++ b/lib/status-bar.coffee
@@ -23,6 +23,7 @@ class StatusBar extends View
     @subscriptions = new CompositeDisposable()
 
     @subscriptions.add atom.commands.add 'atom-workspace',
+      'platformio-ide-terminal:focus': => @activeTerminal.focusTerminal()
       'platformio-ide-terminal:new': => @newTerminalView()
       'platformio-ide-terminal:toggle': => @toggle()
       'platformio-ide-terminal:next': =>


### PR DESCRIPTION
Hi @ivankravets. :smile: This is another feature from my fork I thought I'd send in since you guys seem to have a few requests for it: #145 #62 and #1 if I'm reading 'em correctly. It provides a focus command and a keybinding so you can switch the focus back to the terminal easily.

Cheers!
Fred