### PR TITLE
Rename env variable to correct env variable used in atom

### DIFF
--- a/lib/process.coffee
+++ b/lib/process.coffee
@@ -13,7 +13,7 @@ systemLanguage = do ->
   return language
 
 filteredEnvironment = do ->
-  env = _.omit process.env, 'ATOM_HOME', 'ATOM_SHELL_INTERNAL_RUN_AS_NODE', 'GOOGLE_API_KEY', 'NODE_ENV', 'NODE_PATH', 'userAgent', 'taskPath'
+  env = _.omit process.env, 'ATOM_HOME', 'ELECTRON_RUN_AS_NODE', 'GOOGLE_API_KEY', 'NODE_ENV', 'NODE_PATH', 'userAgent', 'taskPath'
   env.LANG ?= systemLanguage
   env.TERM_PROGRAM = 'platformio-ide-terminal'
   return env


### PR DESCRIPTION
The environmental variable `ATOM_SHELL_INTERNAL_RUN_AS_NODE` was renamed in the atom source code to `ELECTRON_RUN_AS_NODE` a while back, but was apparently never changed in the
platformio-terminal code. Changing `ATOM_SHELL_INTERNAL_RUN_AS_NODE` to `ELECTRON_RUN_AS_NODE` in the `lib/process.coffee`file seems to resolve the issues people have been having not being able to run various commands in the terminal.