### PR TITLE
Open terminal

### DIFF
--- a/lib/platformio-ide-terminal.coffee
+++ b/lib/platformio-ide-terminal.coffee
@@ -15,10 +15,10 @@ module.exports =
       @statusBarTile.runCommandInNewTerminal commands
     getTerminalViews: () =>
       @statusBarTile.terminalViews
+    open: () =>
+      @statusBarTile.runNewTerminal()
 
   provideRunInTerminal: ->
-    new: (commands) =>
-      @statusBarTile.runNewTerminal()
     run: (commands) =>
       @statusBarTile.runCommandInNewTerminal commands
     getTerminalViews: () =>

--- a/lib/platformio-ide-terminal.coffee
+++ b/lib/platformio-ide-terminal.coffee
@@ -8,6 +8,8 @@ module.exports =
     @statusBarTile = null
 
   provideRunInTerminal: ->
+    new: (commands) =>
+      @statusBarTile.runNewTerminal()
     run: (commands) =>
       @statusBarTile.runCommandInNewTerminal commands
     getTerminalViews: () =>

--- a/lib/process.coffee
+++ b/lib/process.coffee
@@ -59,18 +59,22 @@ module.exports = (pwd, shell, args, options={}) ->
       emit('platformio-ide-terminal:title', ptyProcess.process)
     , 500, true
 
+    # TODO: since this is run in a task (seperate thread?), i think that the task is not executed (aka no pty exists yet) when gdb needs the pty in order to start, need some way to wait for pty to exist (or timeout)
+    # Currently able to send the task a message, then the task will emit the pty event
+    console.log("found pty (in process.coffee): ", ptyProcess.pty)
+
     ptyProcess.slave.on 'data', (data) ->
-      console.log("ptyProcess.master data")
+      console.log("ptyProcess.slave data ", data)
       emit('platformio-ide-terminal:data', data)
       emitTitle()
 
     ptyProcess.master.on 'data', (data) ->
-      console.log("ptyProcess.master data")
+      console.log("ptyProcess.master data ", data)
       emit('platformio-ide-terminal:data', data)
       emitTitle()
 
     ptyProcess.slave.on 'exit', ->
-      console.log("ptyProcess.master exit")
+      console.log("ptyProcess.slave exit")
       emit('platformio-ide-terminal:exit')
       callback()
 
@@ -83,3 +87,4 @@ module.exports = (pwd, shell, args, options={}) ->
       switch event
         when 'resize' then ptyProcess.resize(cols, rows)
         when 'input' then ptyProcess.write(text)
+        when 'pty' then emit('platformio-ide-terminal:pty', ptyProcess.pty)

--- a/lib/status-bar.coffee
+++ b/lib/status-bar.coffee
@@ -145,71 +145,35 @@ class StatusBar extends View
         event.originalEvent.dataTransfer.setData 'platformio-ide-terminal-tab', 'true'
       pane.onDidDestroy -> tabBar.off 'drop', @onDropTabBar
 
-  createEmptyTerminalView: () ->
-    @registerPaneSubscription() unless @paneSubscription?
-
-    projectFolder = atom.project.getPaths()[0]
-    editorPath = atom.workspace.getActiveTextEditor()?.getPath()
-
-    if editorPath?
-      editorFolder = path.dirname(editorPath)
-      for directory in atom.project.getPaths()
-        if editorPath.indexOf(directory) >= 0
-          projectFolder = directory
-
-    projectFolder = undefined if projectFolder?.indexOf('atom://') >= 0
-
-    home = if process.platform is 'win32' then process.env.HOMEPATH else process.env.HOME
-
-    switch atom.config.get('platformio-ide-terminal.core.workingDirectory')
-      when 'Project' then pwd = projectFolder or editorFolder or home
-      when 'Active File' then pwd = editorFolder or projectFolder or home
-      else pwd = home
-
-    id = editorPath or projectFolder or home
-    id = filePath: id, folderPath: path.dirname(id)
-
-    # shell = atom.config.get 'platformio-ide-terminal.core.shell'
-    # shellArguments = atom.config.get 'platformio-ide-terminal.core.shellArguments'
-    # args = shellArguments.split(/\s+/g).filter (arg) -> arg
-
-    statusIcon = new StatusIcon()
-    platformIOTerminalView = new PlatformIOTerminalView(id, pwd, statusIcon, this, null, [], [])
-    statusIcon.initialize(platformIOTerminalView)
-
-    platformIOTerminalView.attach()
-
-    @terminalViews.push platformIOTerminalView
-    @statusContainer.append statusIcon
-    return platformIOTerminalView
-
   createTerminalView: (autoRun) ->
-    @registerPaneSubscription() unless @paneSubscription?
-
-    projectFolder = atom.project.getPaths()[0]
-    editorPath = atom.workspace.getActiveTextEditor()?.getPath()
-
-    if editorPath?
-      editorFolder = path.dirname(editorPath)
-      for directory in atom.project.getPaths()
-        if editorPath.indexOf(directory) >= 0
-          projectFolder = directory
-
-    projectFolder = undefined if projectFolder?.indexOf('atom://') >= 0
-
-    home = if process.platform is 'win32' then process.env.HOMEPATH else process.env.HOME
-
-    switch atom.config.get('platformio-ide-terminal.core.workingDirectory')
-      when 'Project' then pwd = projectFolder or editorFolder or home
-      when 'Active File' then pwd = editorFolder or projectFolder or home
-      else pwd = home
-
-    id = editorPath or projectFolder or home
-    id = filePath: id, folderPath: path.dirname(id)
-
     shell = atom.config.get 'platformio-ide-terminal.core.shell'
     shellArguments = atom.config.get 'platformio-ide-terminal.core.shellArguments'
     args = shellArguments.split(/\s+/g).filter (arg) -> arg
+    return createEmptyTerminalView autoRun, shell, args
+
+  createEmptyTerminalView: (autoRun=[], shell = null, args = []) ->
+    @registerPaneSubscription() unless @paneSubscription?
+
+    projectFolder = atom.project.getPaths()[0]
+    editorPath = atom.workspace.getActiveTextEditor()?.getPath()
+
+    if editorPath?
+      editorFolder = path.dirname(editorPath)
+      for directory in atom.project.getPaths()
+        if editorPath.indexOf(directory) >= 0
+          projectFolder = directory
+
+    projectFolder = undefined if projectFolder?.indexOf('atom://') >= 0
+
+    home = if process.platform is 'win32' then process.env.HOMEPATH else process.env.HOME
+
+    switch atom.config.get('platformio-ide-terminal.core.workingDirectory')
+      when 'Project' then pwd = projectFolder or editorFolder or home
+      when 'Active File' then pwd = editorFolder or projectFolder or home
+      else pwd = home
+
+    id = editorPath or projectFolder or home
+    id = filePath: id, folderPath: path.dirname(id)
 
     statusIcon = new StatusIcon()
     platformIOTerminalView = new PlatformIOTerminalView(id, pwd, statusIcon, this, shell, args, autoRun)

--- a/lib/status-bar.coffee
+++ b/lib/status-bar.coffee
@@ -149,7 +149,7 @@ class StatusBar extends View
     shell = atom.config.get 'platformio-ide-terminal.core.shell'
     shellArguments = atom.config.get 'platformio-ide-terminal.core.shellArguments'
     args = shellArguments.split(/\s+/g).filter (arg) -> arg
-    return createEmptyTerminalView autoRun, shell, args
+    @createEmptyTerminalView autoRun, shell, args
 
   createEmptyTerminalView: (autoRun=[], shell = null, args = []) ->
     @registerPaneSubscription() unless @paneSubscription?
@@ -239,6 +239,7 @@ class StatusBar extends View
   runNewTerminal: () ->
     @activeTerminal = @createEmptyTerminalView()
     @activeTerminal.toggle()
+    return @activeTerminal
 
   runCommandInNewTerminal: (commands) ->
     @activeTerminal = @createTerminalView(commands)

--- a/lib/view.coffee
+++ b/lib/view.coffee
@@ -269,13 +269,9 @@ class PlatformIOTerminalView extends View
     @ptyProcess.send {event: 'resize', rows, cols}
 
   pty: () ->
-    console.log("looking for the pty")
-
     if not @opened
       wait = new Promise (resolve, reject) =>
         @emitter.on "platformio-ide-terminal:terminal-open", () =>
-          console.log("terminal is now open!!")
-          #TODO: remove listener?
           resolve()
         setTimeout reject, 300
 
@@ -288,13 +284,10 @@ class PlatformIOTerminalView extends View
     new Promise (resolve, reject) =>
       if @ptyProcess?
         @ptyProcess.on "platformio-ide-terminal:pty", (pty) =>
-          console.log("found pty: ", pty)
-          #TODO: remove listener?
           resolve(pty)
         @ptyProcess.send {event: 'pty'}
         setTimeout reject, 300
       else
-        console.log("no ptyProcess yet")
         reject()
 
   applyStyle: ->

--- a/lib/view.coffee
+++ b/lib/view.coffee
@@ -142,13 +142,22 @@ class PlatformIOTerminalView extends View
       @input data
 
     @ptyProcess.on "platformio-ide-terminal:title", (title) =>
+      console.log("found title: ", title)
       @process = title
     @terminal.on "title", (title) =>
       @title = title
 
+    @ptyProcess.on "platformio-ide-terminal:pty", (pty) =>
+      console.log("found pty: ", pty)
+      @pty = pty
+
+    @ptyProcess.send {event: 'pty'}
+
     @terminal.once "open", =>
       @applyStyle()
       @resizeTerminalToView()
+
+      @pty()
 
       return unless @ptyProcess.childProcess?
       autoRunCommand = atom.config.get('platformio-ide-terminal.core.autoRunCommand')
@@ -266,6 +275,11 @@ class PlatformIOTerminalView extends View
     return unless @ptyProcess.childProcess?
 
     @ptyProcess.send {event: 'resize', rows, cols}
+
+  pty: () ->
+    return unless @ptyProcess.childProcess?
+
+    @ptyProcess.send {event: 'pty'}
 
   applyStyle: ->
     config = atom.config.get 'platformio-ide-terminal'

--- a/lib/view.coffee
+++ b/lib/view.coffee
@@ -273,7 +273,7 @@ class PlatformIOTerminalView extends View
       wait = new Promise (resolve, reject) =>
         @emitter.on "platformio-ide-terminal:terminal-open", () =>
           resolve()
-        setTimeout reject, 300
+        setTimeout reject, 1000
 
       wait.then () =>
         @ptyPromise()
@@ -286,7 +286,7 @@ class PlatformIOTerminalView extends View
         @ptyProcess.on "platformio-ide-terminal:pty", (pty) =>
           resolve(pty)
         @ptyProcess.send {event: 'pty'}
-        setTimeout reject, 300
+        setTimeout reject, 1000
       else
         reject()
 

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "platformioIDETerminal": {
       "description": "PlatformIO IDE Terminal API",
       "versions": {
-        "1.0.0": "providePlatformIOIDETerminal"
+        "1.1.0": "providePlatformIOIDETerminal"
       }
     },
     "runInTerminal": {


### PR DESCRIPTION
Adds PlatformIOIDETerminal:open API call.

It opens a unconnected pty terminal instead of opening a process in a terminal.

Used in [gdb debugger](https://github.com/31i73/atom-dbg-gdb/pull/16) to separate gdb and application terminal io.