### PR TITLE
Fix resizing when atom footer panel is not empty

### DIFF
--- a/lib/view.coffee
+++ b/lib/view.coffee
@@ -402,7 +402,7 @@ class PlatformIOTerminalView extends View
     return @resizeStopped() unless event.which is 1
 
     mouseY = $(window).height() - event.pageY
-    delta = mouseY - $('atom-panel-container.bottom').height()
+    delta = mouseY - $('atom-panel-container.bottom').height() - $('atom-panel-container.footer').height()
     return unless Math.abs(delta) > (@rowHeight * 5 / 6)
 
     clamped = Math.max(@nearestRow(@prevHeight + delta), @rowHeight)


### PR DESCRIPTION
Terminal panel resizing has a bug (the height of the footer panels is not substracted from the delta during `resizePanel`) when any panel in the `atom-panel-container[@class='footer']` is visible. 

Example (the `go-plus` extension is in the footer panel):

![image](https://cloud.githubusercontent.com/assets/1585112/24581588/7fe102d8-171e-11e7-8664-4f371f59982c.png)
