### PR TITLE
Fix focus (ctrl+alt+F) shortcut behaviour

### DIFF
--- a/lib/status-bar.coffee
+++ b/lib/status-bar.coffee
@@ -23,7 +23,7 @@ class StatusBar extends View
     @subscriptions = new CompositeDisposable()
 
     @subscriptions.add atom.commands.add 'atom-workspace',
-      'platformio-ide-terminal:focus': => @activeTerminal.focusTerminal()
+      'platformio-ide-terminal:focus': => @focusTerminal()
       'platformio-ide-terminal:new': => @newTerminalView()
       'platformio-ide-terminal:toggle': => @toggle()
       'platformio-ide-terminal:next': =>
@@ -211,6 +211,11 @@ class StatusBar extends View
 
   getActiveTerminalView: ->
     return @activeTerminal
+  
+  focusTerminal: ->
+    return unless @activeTerminal?
+
+    @activeTerminal.focusTerminal()
 
   getTerminalById: (target, selector) ->
     selector ?= (terminal) -> terminal.id

--- a/lib/status-bar.coffee
+++ b/lib/status-bar.coffee
@@ -211,11 +211,14 @@ class StatusBar extends View
 
   getActiveTerminalView: ->
     return @activeTerminal
-  
+
   focusTerminal: ->
     return unless @activeTerminal?
 
-    @activeTerminal.focusTerminal()
+    if terminal = PlatformIOTerminalView.getFocusedTerminal()
+        @activeTerminal.blur()
+    else
+        @activeTerminal.focusTerminal()
 
   getTerminalById: (target, selector) ->
     selector ?= (terminal) -> terminal.id

--- a/lib/view.coffee
+++ b/lib/view.coffee
@@ -467,6 +467,8 @@ class PlatformIOTerminalView extends View
   focusTerminal: =>
     return unless @terminal
 
+    lastActiveElement = $(document.activeElement)
+
     @terminal.focus()
     if @terminal._textarea
       @terminal._textarea.focus()

--- a/lib/view.coffee
+++ b/lib/view.coffee
@@ -479,6 +479,9 @@ class PlatformIOTerminalView extends View
     @terminal.blur()
     @terminal.element.blur()
 
+    if lastActiveElement?
+      lastActiveElement.focus()
+
   resizeTerminalToView: ->
     return unless @panel.isVisible() or @tabView
 


### PR DESCRIPTION
Previous behaviour:
* If the terminal is not focused, focus the terminal
* If the terminal is focused, do nothing
* If the terminal is not visible, crash (issue #189)

Current behaviour:
* If the terminal is not focused, focus the terminal
* If the terminal is focused, return focus to last active element
* If the terminal is not visible, do nothing (fix issue #189)