### PR TITLE
Fix theme colors for one-dark and solarized-dark

### DIFF
--- a/styles/themes/one-dark.less
+++ b/styles/themes/one-dark.less
@@ -3,10 +3,10 @@
   color: #ABB2BF;
 
   ::selection {
-    background-color: #44475a;
+    background-color: #9196A1;
   }
 
   .terminal-cursor {
-    background-color: #99BBFF;
+    background-color: #528BFF;
   }
 }

--- a/styles/themes/solarized-dark.less
+++ b/styles/themes/solarized-dark.less
@@ -3,7 +3,7 @@
   color: #708284;
 
   ::selection {
-    background-color: #475B62;
+    background-color: #839496;
   }
 
   .terminal-cursor {


### PR DESCRIPTION
Corrected the following themes:
- one-dark
    - cursor to match editor theme color
    - selection (highlight) color to match editor color

- solarized-dark
    - selection (highlight) to be visible (https://github.com/platformio/platformio-atom-ide-terminal/issues/102)
