### PR TITLE
Replace the unmaintained pty.js with node-pty

### DIFF
--- a/lib/process.coffee
+++ b/lib/process.coffee
@@ -1,4 +1,4 @@
-pty = require 'pty.js'
+pty = require 'node-pty'
 path = require 'path'
 fs = require 'fs'
 _ = require 'underscore'

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "atom-space-pen-views": "^2.1.0",
-    "pty.js": "https://github.com/platformio/pty.js/tarball/prebuilt",
+    "node-pty": "^0.7.3",
     "term.js": "https://github.com/jeremyramin/term.js/tarball/master",
     "underscore": "^1.8.3"
   },


### PR DESCRIPTION
Note that this uses the npm version instead of a prebuilt tar. Which means users will have to build it, but it also means we will get semver compatible updates.

Potentially ~fixes~ #422 and others.

This is a rather blind replacement, hopefully there is no API break...