### PR TITLE
Switch from `pty.js` to `node.pty` with `node-pty-prebuilt`

### DIFF
--- a/lib/process.coffee
+++ b/lib/process.coffee
@@ -1,4 +1,4 @@
-pty = require 'pty.js'
+pty = require 'node-pty-prebuilt'
 path = require 'path'
 fs = require 'fs'
 _ = require 'underscore'

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "atom-space-pen-views": "^2.1.0",
-    "pty.js": "https://github.com/platformio/pty.js/tarball/prebuilt",
+    "node-pty-prebuilt": "^0.7.3",
     "term.js": "https://github.com/jeremyramin/term.js/tarball/master",
     "underscore": "^1.8.3"
   },


### PR DESCRIPTION
Follow up to #547

Tested working on Win10 and Atom 1.27.2 (`chrome:58.0.3029.110`, `electron:1.7.15`)


