### PR TITLE
Move bottom controls to left

### DIFF
--- a/styles/platformio-ide-terminal.less
+++ b/styles/platformio-ide-terminal.less
@@ -102,6 +102,7 @@
   }
 
   &.status-bar {
+    float: left;
     position: relative;
     vertical-align: middle;
     display: inline;
@@ -112,7 +113,7 @@
 
     i {
       cursor: pointer;
-      display: inherit;
+      display: inline;
       text-align: center;
       align-self: center;
       line-height: @status-bar-height;
@@ -123,7 +124,7 @@
     }
 
     .status-container {
-      display: inherit;
+      display: inline;
       position: relative;
       width: 100%;
       height: 100%;


### PR DESCRIPTION
If `atom-ide-ui` installed, bottom controls are after errors/warnings
My user style to fix this
```less
.platformio-ide-terminal.status-bar {
  float: left;
  i, .status-container {
    display: inline;
  }
}
```
Before 
![atom_2018-06-26_04-15-21](https://user-images.githubusercontent.com/12619075/41867983-056f6836-78f8-11e8-9c4b-123e291873c0.png)
After 
![atom_2018-06-26_04-16-09](https://user-images.githubusercontent.com/12619075/41867996-0cfbc5ea-78f8-11e8-98dc-947e822ec8d9.png)

