### PR TITLE
Mac conflict shortcut conflict.

### DIFF
--- a/keymaps/platformio-ide-terminal.cson
+++ b/keymaps/platformio-ide-terminal.cson
@@ -1,5 +1,5 @@
 '.platform-darwin atom-workspace':
-  'cmd-shift-t': 'platformio-ide-terminal:new'
+  'cmd-alt-t': 'platformio-ide-terminal:new'
   'cmd-shift-j': 'platformio-ide-terminal:prev'
   'cmd-shift-k': 'platformio-ide-terminal:next'
   'cmd-shift-x': 'platformio-ide-terminal:close'


### PR DESCRIPTION
There  is a conflict between reopen last item and new terminal. Hence changed shortcut of new terminal from cmd-shift-t to cmd-alt-t.