### PR TITLE
Use atom syntax for standard style

### DIFF
--- a/styles/themes/standard.less
+++ b/styles/themes/standard.less
@@ -1,8 +1,10 @@
+@import "syntax-variables";
+
 .standard {
-  background-color: black;
-  color: white;
+  background-color: @syntax-background-color;
+  color: @syntax-text-color;
 
   .terminal-cursor {
-    background-color: white;
+    background-color: @syntax-cursor-color;
   }
 }


### PR DESCRIPTION
Uses syntax-variables for variables in standard.
Fixes #605 