### PR TITLE
Fix .platformio-ide-terminal.status-bar styles

### DIFF
--- a/styles/platformio-ide-terminal.less
+++ b/styles/platformio-ide-terminal.less
@@ -103,12 +103,10 @@
 
   &.status-bar {
     position: relative;
-    vertical-align: middle;
     display: inline;
     -webkit-user-select: none;
     margin: 0 10px;
     box-sizing: content-box;
-    height: @status-bar-height;
 
     i {
       cursor: pointer;


### PR DESCRIPTION
### Pull request details
Fix .platformio-ide-terminal.status-bar styles

### Description of the change
1. We can't set `height` of `inline` element.
2. `vertical-align` property is redundant. Without it panel looks better, screenshots are included.

Panel with vertical-align property set
![screenshot 2019-05-23-35 001](https://user-images.githubusercontent.com/31389848/58228307-97303f80-7d2e-11e9-9d63-f7a0fe73b5bb.png)

Panel without vertical-align and height properties set
![screenshot 2019-05-23-06 002](https://user-images.githubusercontent.com/31389848/58228320-9e574d80-7d2e-11e9-81a7-7fec53631ee2.png)


### Notes
Fix vertical align of platformio panel in atom status bar.

MOD-EDIT: added screenshots inline.