### PR TITLE
Fix #230 - render in dock

### DIFF
--- a/lib/platformio-ide-terminal.coffee
+++ b/lib/platformio-ide-terminal.coffee
@@ -2,6 +2,10 @@ module.exports =
   statusBar: null
 
   activate: ->
+    atom.config.onDidChange 'platformio-ide-terminal.toggles.useDock', (event) =>
+      if @statusBarProvider
+        @deactivate()
+        @consumeStatusBar(@statusBarProvider)
 
   deactivate: ->
     @statusBarTile?.destroy()
@@ -24,14 +28,19 @@ module.exports =
     getTerminalViews: () =>
       @statusBarTile.terminalViews
 
-  consumeStatusBar: (statusBarProvider) ->
-    @statusBarTile = new (require './status-bar')(statusBarProvider)
+  consumeStatusBar: (@statusBarProvider) ->
+    @statusBarTile = new (require './status-bar')(@statusBarProvider)
 
   config:
     toggles:
       type: 'object'
       order: 1
       properties:
+        useDock:
+          title: 'Use Bottom Dock'
+          description: 'Should the terminals be rendered in a dock?'
+          type: 'boolean'
+          default: false
         autoClose:
           title: 'Close Terminal on Exit'
           description: 'Should the terminal close if the shell exits?'

--- a/lib/status-bar.coffee
+++ b/lib/status-bar.coffee
@@ -315,8 +315,7 @@ class StatusBar extends View
   destroy: ->
     @subscriptions.dispose()
     for view in @terminalViews
-      view.ptyProcess.terminate()
-      view.terminal.destroy()
+      view.destroy()
     @detach()
 
   toggle: ->

--- a/lib/status-bar.coffee
+++ b/lib/status-bar.coffee
@@ -78,7 +78,7 @@ class StatusBar extends View
               nextTerminal = @createTerminalView()
           else
             @setActiveTerminalView(nextTerminal)
-            nextTerminal.toggle() if prevTerminal?.panel.isVisible()
+            nextTerminal.toggle() if prevTerminal?.panel?.isVisible()
 
     @registerContextMenu()
 

--- a/lib/status-bar.coffee
+++ b/lib/status-bar.coffee
@@ -78,7 +78,8 @@ class StatusBar extends View
               nextTerminal = @createTerminalView()
           else
             @setActiveTerminalView(nextTerminal)
-            nextTerminal.toggle() if prevTerminal?.panel?.isVisible()
+            if prevTerminal?.panel?.isVisible() or atom.workspace.getBottomDock().isVisible()
+              nextTerminal.toggle()
 
     @registerContextMenu()
 

--- a/lib/status-bar.coffee
+++ b/lib/status-bar.coffee
@@ -1,8 +1,10 @@
 {CompositeDisposable} = require 'atom'
 {$, View} = require 'atom-space-pen-views'
 
+InputDialog = null
 PlatformIOTerminalView = require './view'
 StatusIcon = require './status-icon'
+{getDockSetting} = require './utils'
 
 os = require 'os'
 path = require 'path'
@@ -19,6 +21,7 @@ class StatusBar extends View
       @i class: "icon icon-plus", click: 'newTerminalView', outlet: 'plusBtn'
       @ul class: "list-inline status-container", tabindex: '-1', outlet: 'statusContainer', is: 'space-pen-ul'
       @i class: "icon icon-x", click: 'closeAll', outlet: 'closeBtn'
+      if not getDockSetting() then null else @i class: 'icon icon-keyboard', style: 'margin-left: 10px', outlet: 'inputBtn', click: 'inputDialog'
 
   initialize: (@statusBarProvider) ->
     @subscriptions = new CompositeDisposable()
@@ -312,6 +315,12 @@ class StatusBar extends View
       if view?
         view.destroy()
     @activeTerminal = null
+
+  inputDialog: ->
+    if not @activeTerminal then return
+    InputDialog ?= require('./input-dialog')
+    dialog = new InputDialog @activeTerminal
+    dialog.attach()
 
   destroy: ->
     @subscriptions.dispose()

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,23 @@
+'use babel';
+
+const isString = x => typeof x === "string"
+
+export function isVisible(itemOrUri) {
+  const uri = isString(itemOrUri) ? itemOrUri : itemOrUri.getURI();
+
+  const container = atom.workspace.paneContainerForURI(uri);
+  if (container) {
+    const activeItem = container.getActivePaneItem();
+    if (!activeItem) return false;
+    const viewIsActive = activeItem.getURI && activeItem.getURI() === uri;
+    if (container.getLocation() !== "center") {
+      return container.isVisible() && viewIsActive;
+    }
+    return viewIsActive;
+  }
+  return false;
+}
+
+// export function getDock(itemOrUri) {
+//   return atom.workspace.paneContainerForURI(isString(itemOrUri) ? itemOrUri : itemOrUri.getURI())
+// }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,23 +1,16 @@
-'use babel';
+"use babel";
 
-const isString = x => typeof x === "string"
+const isString = x => typeof x === "string";
 
+// visibility for items in bottom dock
 export function isVisible(itemOrUri) {
   const uri = isString(itemOrUri) ? itemOrUri : itemOrUri.getURI();
 
-  const container = atom.workspace.paneContainerForURI(uri);
-  if (container) {
-    const activeItem = container.getActivePaneItem();
-    if (!activeItem) return false;
-    const viewIsActive = activeItem.getURI && activeItem.getURI() === uri;
-    if (container.getLocation() !== "center") {
-      return container.isVisible() && viewIsActive;
-    }
-    return viewIsActive;
-  }
-  return false;
-}
+  const dock = atom.workspace.getBottomDock();
+  if (!dock.isVisible()) return false
 
-// export function getDock(itemOrUri) {
-//   return atom.workspace.paneContainerForURI(isString(itemOrUri) ? itemOrUri : itemOrUri.getURI())
-// }
+  const activeItem = dock.getActivePaneItem();
+  if (!activeItem) return false;
+
+  return activeItem.getURI && activeItem.getURI() === uri;
+}

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -14,3 +14,5 @@ export function isVisible(itemOrUri) {
 
   return activeItem.getURI && activeItem.getURI() === uri;
 }
+
+export const getDockSetting = () => atom.config.get('platformio-ide-terminal.toggles.useDock')

--- a/lib/view.coffee
+++ b/lib/view.coffee
@@ -8,12 +8,10 @@ InputDialog = null
 path = require 'path'
 os = require 'os'
 
-{isVisible} = require './utils'
+{isVisible, getDockSetting} = require './utils'
 
 lastOpenedView = null
 lastActiveElement = null
-
-getDockSetting = -> atom.config.get('platformio-ide-terminal.toggles.useDock')
 
 nextId = 0
 
@@ -32,11 +30,11 @@ class PlatformIOTerminalView extends View
   @content: ->
     @div class: 'platformio-ide-terminal terminal-view', outlet: 'platformIOTerminalView', =>
       @div class: 'panel-divider', outlet: 'panelDivider'
-      @section class: 'input-block', =>
+      if getDockSetting() then null else @section class: 'input-block', =>
         @div class: 'btn-toolbar', =>
           @div class: 'btn-group', =>
             @button outlet: 'inputBtn', class: 'btn icon icon-keyboard', click: 'inputDialog'
-          if getDockSetting() then null else @div class: 'btn-group right', =>
+          @div class: 'btn-group right', =>
             @button outlet: 'hideBtn', class: 'btn icon icon-chevron-down', click: 'hide'
             @button outlet: 'maximizeBtn', class: 'btn icon icon-screen-full', click: 'maximize'
             @button outlet: 'closeBtn', class: 'btn icon icon-x', click: 'destroy'
@@ -68,8 +66,8 @@ class PlatformIOTerminalView extends View
         title: 'Hide'
       @subscriptions.add @maximizeBtn.tooltip = atom.tooltips.add @maximizeBtn,
         title: 'Fullscreen'
-    @inputBtn.tooltip = atom.tooltips.add @inputBtn,
-      title: 'Insert Text'
+      @inputBtn.tooltip = atom.tooltips.add @inputBtn,
+        title: 'Insert Text'
 
     @prevHeight = atom.config.get('platformio-ide-terminal.style.defaultPanelHeight')
     if @prevHeight.indexOf('%') > 0


### PR DESCRIPTION
### Pull request details
<!--Tick the appropriate box by adding an x in between the [] to ID the PR type-->
- [ ] This PR is a bug fix
- [x] This PR implements a new feature or introduces new behavior.

### Description of the change
Atom introduced [Docks](https://blog.atom.io/2017/05/16/atom-1-17.html) 2 years ago as a good place for some elements including terminals. This PR renders the terminal view within a tab inside the bottom dock.  Fixes #230

### Notes
Being in the dock provides consistency in atom UX.