### PR TITLE
Update themes on config changes

### DIFF
--- a/lib/view.coffee
+++ b/lib/view.coffee
@@ -301,6 +301,11 @@ class PlatformIOTerminalView extends View
     config = atom.config.get 'platformio-ide-terminal'
 
     @xterm.addClass config.style.theme
+    
+    @subscriptions.add atom.config.onDidChange 'platformio-ide-terminal.style.theme', (event) =>
+      @xterm.removeClass event.oldValue
+      @xterm.addClass event.newValue
+
     @xterm.addClass 'cursor-blink' if config.toggles.cursorBlink
 
     editorFont = atom.config.get('editor.fontFamily')


### PR DESCRIPTION
### Pull request details
<!--Tick the appropriate box by adding an x in between the [] to ID the PR type-->
- [ ] This PR is a bug fix
- [X] This PR implements a new feature or introduces new behavior.

### Description of the change
<!-- We must be able to understand the design of your change from this description.
Please walk us through the concepts. -->

It is extremely useful to be able to see the themes update when switching the theme in "Settings". This way you can now cycle through the themes to see which you like most without needing to close and re-open the terminal after each choice.

![giphy](https://user-images.githubusercontent.com/6043371/66725007-d739b100-edfa-11e9-8bfe-c9a5a1fafe75.gif)