### PR TITLE
Add setting to disable toolbar buttons

### DIFF
--- a/lib/platformio-ide-terminal.coffee
+++ b/lib/platformio-ide-terminal.coffee
@@ -57,6 +57,11 @@ module.exports =
           description: 'Use --login on zsh and bash.'
           type: 'boolean'
           default: true
+        showToolbar:
+          title: 'Show Toolbar'
+          description: 'Show toolbar above terminal window.'
+          type: 'boolean'
+          default: true
     core:
       type: 'object'
       order: 2

--- a/lib/view.coffee
+++ b/lib/view.coffee
@@ -27,7 +27,7 @@ class PlatformIOTerminalView extends View
     @div class: 'platformio-ide-terminal terminal-view', outlet: 'platformIOTerminalView', =>
       @div class: 'panel-divider', outlet: 'panelDivider'
       @section class: 'input-block', =>
-        @div class: 'btn-toolbar', =>
+        @div outlet: 'toolbar', class: 'btn-toolbar', =>
           @div class: 'btn-group', =>
             @button outlet: 'inputBtn', class: 'btn icon icon-keyboard', click: 'inputDialog'
           @div class: 'btn-group right', =>
@@ -61,6 +61,9 @@ class PlatformIOTerminalView extends View
 
     @setAnimationSpeed()
     @subscriptions.add atom.config.onDidChange 'platformio-ide-terminal.style.animationSpeed', @setAnimationSpeed
+
+    @updateToolbarVisibility()
+    @subscriptions.add atom.config.onDidChange 'platformio-ide-terminal.toggles.showToolbar', @updateToolbarVisibility
 
     override = (event) ->
       return if event.originalEvent.dataTransfer.getData('platformio-ide-terminal') is 'true'
@@ -98,6 +101,13 @@ class PlatformIOTerminalView extends View
     @animationSpeed = 100 if @animationSpeed is 0
 
     @xterm.css 'transition', "height #{0.25 / @animationSpeed}s linear"
+
+  updateToolbarVisibility: =>
+    @showToolbar = atom.config.get('platformio-ide-terminal.toggles.showToolbar')
+    if @showToolbar
+      @toolbar.css 'display', 'block'
+    else
+      @toolbar.css 'display', 'none'
 
   recieveItemOrFile: (event) =>
     event.preventDefault()


### PR DESCRIPTION
Fixes #580

### Pull request details
<!--Tick the appropriate box by adding an x in between the [] to ID the PR type-->
- [ ] This PR is a bug fix
- [x] This PR implements a new feature or introduces new behavior.

### Description of the change
<!-- We must be able to understand the design of your change from this description.
Please walk us through the concepts. -->
Adds a setting to disable the toolbar buttons.
### Notes
<!--
Please describe the changes in a single line that explains this improvement in
terms that a user can understand.
-->
The toolbar buttons aren't strictly needed, they can all be accessed via other UI or keyboard shortcuts if desired. Some users may find it useful to hide the buttons (as seen in #580) and regain screen real estate for code.

![image](https://user-images.githubusercontent.com/6043371/66725265-34833180-edfe-11e9-9fc2-96287e77e587.png)

