### PR TITLE
Change README according to keymaps/platformio-ide-terminal.cson

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,14 +126,14 @@ Toggling the `Auto Open a New Terminal (For Terminal Mapping)` option will have 
 ## Commands
 | Command | Action | Default Keybind |
 |---------|--------|:-----------------:|
-| platformio-ide-terminal:new | Create a new terminal instance. | `ctrl-shift-t`<br>or<br>`cmd-shift-t` |
+| platformio-ide-terminal:new | Create a new terminal instance. | `alt-shift-t`<br>or<br>`cmd-shift-t` |
 | platformio-ide-terminal:toggle | Toggle the last active terminal instance.<br>**Note:** This will create a new terminal if it needs to. | `` ctrl-` ``<br>(Control + Backtick) |
-| platformio-ide-terminal:prev | Switch to the terminal left of the last active terminal. | `ctrl-shift-j`<br>or<br>`cmd-shift-j` |
-| platformio-ide-terminal:next | Switch to the terminal right of the last active terminal. | `ctrl-shift-k`<br>or<br>`cmd-shift-k` |
+| platformio-ide-terminal:prev | Switch to the terminal left of the last active terminal. | `alt-shift-j`<br>or<br>`cmd-shift-j` |
+| platformio-ide-terminal:next | Switch to the terminal right of the last active terminal. | `alt-shift-k`<br>or<br>`cmd-shift-k` |
 | platformio-ide-terminal:insert-selected-text | Run the selected text as a command in the active terminal. | `ctrl-enter` |
 | platformio-ide-terminal:insert-text | Bring up an input box for using IME and special keys. | –––––––––––– |
 | platformio-ide-terminal:fullscreen | Toggle fullscreen for active terminal. | –––––––––––– |
-| platformio-ide-terminal:close | Close the active terminal. | `ctrl-shift-x`<br>or<br>`cmd-shift-x` |
+| platformio-ide-terminal:close | Close the active terminal. | `alt-shift-x`<br>or<br>`cmd-shift-x` |
 | platformio-ide-terminal:close-all | Close all terminals. | –––––––––––– |
 | platformio-ide-terminal:rename | Rename the active terminal. | –––––––––––– |
 


### PR DESCRIPTION
Change README according to [platform-ide-terminal.cson](https://github.com/platformio/platformio-atom-ide-terminal/blob/master/keymaps/platformio-ide-terminal.cson).

### Pull request details
<!--Tick the appropriate box by adding an x in between the [] to ID the PR type-->
- [x] This PR is a bug fix.
- [ ] This PR implements a new feature or introduces new behavior.

### Description of the change
<!-- We must be able to understand the design of your change from this description.
Please walk us through the concepts. -->

`README.md` file is wrong according  [platform-ide-terminal.cson](https://github.com/platformio/platformio-atom-ide-terminal/blob/master/keymaps/platformio-ide-terminal.cson), meaning that lines [L11](https://github.com/platformio/platformio-atom-ide-terminal/blob/f61084493ed48db11d2e54d39e01c1b88e693654/keymaps/platformio-ide-terminal.cson#L11) to [L14](https://github.com/platformio/platformio-atom-ide-terminal/blob/f61084493ed48db11d2e54d39e01c1b88e693654/keymaps/platformio-ide-terminal.cson#L14) in that file suggest that the commands on _Windows_ and _Linux_ platforms should use `alt+...` shortcuts to perform that actions, while the `REAMDE.md` stated to use `ctrl+...` instead. 

### Notes
<!--
Please describe the changes in a single line that explains this improvement in
terms that a user can understand.
-->

This could be implemented the other way around, changing `keymaps/platformio-ide-terminal.cson` and untouching the `README.md`.