### PR TITLE
Update node-pty-prebuilt-multiarch

### DIFF
--- a/lib/status-icon.coffee
+++ b/lib/status-icon.coffee
@@ -97,4 +97,4 @@ class StatusIcon extends HTMLElement
       @name.innerHTML = name
       @terminalView.emit 'did-change-title'
 
-module.exports = document.registerElement('pio-terminal-status-icon', prototype: StatusIcon.prototype, extends: 'li')
+module.exports = customElements.define('pio-terminal-status-icon', prototype: StatusIcon.prototype, extends: 'li')

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "atom-space-pen-views": "^2.2.0",
-    "node-pty-prebuilt-multiarch": "^0.9.0",
+    "node-pty-prebuilt-multiarch": "^0.10.1-pre.5",
     "term.js": "https://github.com/jeremyramin/term.js/tarball/master",
     "underscore": "^1.8.3"
   },


### PR DESCRIPTION
Update node-pty-prebuilt-multiarch from 0.9.0 to 0.10.1-pre.5. According to [their author's comment](https://github.com/oznu/node-pty-prebuilt-multiarch/issues/17#issuecomment-1105934956), 0.10.1-pre.5 supports Electron 11.4.7 on which Atom 1.63.1 is based.

Not sure if this works yet. Not sure if I can install specific branch or commit via apm so this is testing.

### Pull request details
<!--Tick the appropriate box by adding an x in between the [] to ID the PR type-->
- [x] This PR is a bug fix
- [ ] This PR implements a new feature or introduces new behavior.

### Description of the change
<!-- We must be able to understand the design of your change from this description.
Please walk us through the concepts. -->

### Notes
<!--
Please describe the changes in a single line that explains this improvement in
terms that a user can understand.
-->
